### PR TITLE
Update CFBundleVersion plist

### DIFF
--- a/SocketRocket/Resources/Info.plist
+++ b/SocketRocket/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
Hello,
We are facing this issue when we try to upload our build on the App Store.
```
"This bundle Payload/MyApp.app/Frameworks/SocketRocket.framework is invalid. The Info.plist file is missing the required key: CFBundleVersion. Please find more information about CFBundleVersion at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion"
```
The CFBundleVersion references a `CURRENT_PROJECT_VERSION`, which is not present in the project. So I've put the same version as in the short version.