### PR TITLE
Fix Thread Performance Checker warning in Xcode 14

### DIFF
--- a/SocketRocket/Internal/RunLoop/SRRunLoopThread.m
+++ b/SocketRocket/Internal/RunLoop/SRRunLoopThread.m
@@ -29,6 +29,7 @@
     dispatch_once(&onceToken, ^{
         thread = [[SRRunLoopThread alloc] init];
         thread.name = @"com.facebook.SocketRocket.NetworkThread";
+        thread.qualityOfService = NSQualityOfServiceUserInitiated;
         [thread start];
     });
     return thread;


### PR DESCRIPTION
Contains a fix for https://github.com/facebookincubator/SocketRocket/issues/648.