### PR TITLE
Add visionOS support

### DIFF
--- a/SocketRocket.podspec
+++ b/SocketRocket.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target  = '11.0'
   s.osx.deployment_target  = '10.13'
   s.tvos.deployment_target = '11.0'
+  s.visionos.deployment_target = '1.0'
 
   s.ios.frameworks     = 'CFNetwork', 'Security'
   s.osx.frameworks     = 'CoreServices', 'Security'


### PR DESCRIPTION
With the release of [CocoaPods v1.13.0](https://github.com/CocoaPods/CocoaPods/releases/tag/1.13.0), visionOS support was introduced.