### PR TITLE
Fix close code handling in SRWebSocket

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1488,8 +1488,12 @@ static const size_t SRFrameHeaderOverhead = 32;
                         // If we get closed in this state it's probably not clean because we should be sending this when we send messages
                         [self.delegateController performDelegateBlock:^(id<SRWebSocketDelegate>  _Nullable delegate, SRDelegateAvailableMethods availableMethods) {
                             if (availableMethods.didCloseWithCode) {
+                                NSInteger closeCode = SRStatusCodeGoingAway;
+                                if (closeCodeIsValid(self->_closeCode)) {
+                                    closeCode = self->_closeCode;
+                                }
                                 [delegate webSocket:self
-                                   didCloseWithCode:SRStatusCodeGoingAway
+                                   didCloseWithCode:closeCode
                                              reason:@"Stream end encountered"
                                            wasClean:NO];
                             }


### PR DESCRIPTION
Pass the correct closecode to the delegate.

#577 