### PR TITLE
Ensure readyState is set to SR_CLOSED on successful WebSocket closure

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1113,6 +1113,8 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
             }
         }
 
+        self.readyState = SR_CLOSED;
+
         if (!_failed) {
             [self.delegateController performDelegateBlock:^(id<SRWebSocketDelegate>  _Nullable delegate, SRDelegateAvailableMethods availableMethods) {
                 if (availableMethods.didCloseWithCode) {

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1113,9 +1113,8 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
             }
         }
 
-        self.readyState = SR_CLOSED;
-
         if (!_failed) {
+            self.readyState = SR_CLOSED;
             [self.delegateController performDelegateBlock:^(id<SRWebSocketDelegate>  _Nullable delegate, SRDelegateAvailableMethods availableMethods) {
                 if (availableMethods.didCloseWithCode) {
                     [delegate webSocket:self didCloseWithCode:self->_closeCode reason:self->_closeReason wasClean:YES];


### PR DESCRIPTION
This PR fixes an issue where the `readyState` was not properly set to `SR_CLOSED` when the WebSocket closed successfully.

### Changes:
- Previously, during a successful WebSocket closure, the `readyState` remained at `SR_CLOSING` and was not updated to `SR_CLOSED`.
- With this fix, the `readyState` is now set to `SR_CLOSED` before the delegate method responsible for handling the WebSocket closure is called.