### PR TITLE
Deprecate SRStatusNoStatusReceived and update naming for consistency

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -27,7 +27,8 @@ typedef NS_ENUM(NSInteger, SRStatusCode) {
     SRStatusCodeProtocolError = 1002,
     SRStatusCodeUnhandledType = 1003,
     // 1004 reserved.
-    SRStatusNoStatusReceived = 1005,
+    SRStatusCodeNoStatusReceived = 1005,
+    SRStatusNoStatusReceived __deprecated_enum_msg("Use SRStatusCodeNoStatusReceived") = SRStatusCodeNoStatusReceived,
     SRStatusCodeAbnormal = 1006,
     SRStatusCodeInvalidUTF8 = 1007,
     SRStatusCodePolicyViolated = 1008,

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -772,7 +772,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
             }
         }
     } else {
-        _closeCode = SRStatusNoStatusReceived;
+        _closeCode = SRStatusCodeNoStatusReceived;
     }
 
     [self assertOnWorkQueue];


### PR DESCRIPTION
This PR introduces a renaming of `SRStatusNoStatusReceived` to `SRStatusCodeNoStatusReceived` for better consistency with the existing naming conventions. The old constant is now marked as deprecated with a message guiding developers to use the new `SRStatusCodeNoStatusReceived` instead.

Additionally, the updated naming makes it easier to write clean and understandable code in Swift, as shown in this example:
```swift
func testSRStatusCode() throws {
    XCTAssertEqual(SRStatusCode.normal.rawValue, 1000)
    XCTAssertEqual(SRStatusCode.goingAway.rawValue, 1001)
    XCTAssertEqual(SRStatusCode.protocolError.rawValue, 1002)
    XCTAssertEqual(SRStatusCode.unhandledType.rawValue, 1003)
    XCTAssertEqual(SRStatusCode.noStatusReceived.rawValue, 1005)
    XCTAssertEqual(SRStatusCode.abnormal.rawValue, 1006)
    XCTAssertEqual(SRStatusCode.invalidUTF8.rawValue, 1007)
    XCTAssertEqual(SRStatusCode.policyViolated.rawValue, 1008)
    XCTAssertEqual(SRStatusCode.messageTooBig.rawValue, 1009)
    XCTAssertEqual(SRStatusCode.missingExtension.rawValue, 1010)
    XCTAssertEqual(SRStatusCode.internalError.rawValue, 1011)
    XCTAssertEqual(SRStatusCode.serviceRestart.rawValue, 1012)
    XCTAssertEqual(SRStatusCode.tryAgainLater.rawValue, 1013)
    XCTAssertEqual(SRStatusCode.tlsHandshake.rawValue, 1015)
}
```