### PR TITLE
Use SRStatusCode instead of NSInteger for close codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You implement this
 - (void)webSocket:(SRWebSocket *)webSocket didReceiveMessageWithData:(NSData *)data;
 
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error;
-- (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(nullable NSString *)reason wasClean:(BOOL)wasClean;
+- (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(SRStatusCode)code reason:(nullable NSString *)reason wasClean:(BOOL)wasClean;
 
 @end
 ```

--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -256,7 +256,7 @@ extern NSString *const SRHTTPResponseErrorKey;
  @param code   Code to close the socket with.
  @param reason Reason to send to the server or `nil`.
  */
-- (void)closeWithCode:(NSInteger)code reason:(nullable NSString *)reason;
+- (void)closeWithCode:(SRStatusCode)code reason:(nullable NSString *)reason;
 
 ///--------------------------------------
 #pragma mark Send
@@ -385,7 +385,7 @@ extern NSString *const SRHTTPResponseErrorKey;
  @param reason    Reason in a form of a String that was reported by the server or `nil`.
  @param wasClean  Boolean value indicating whether a socket was closed in a clean state.
  */
-- (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(nullable NSString *)reason wasClean:(BOOL)wasClean;
+- (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(SRStatusCode)code reason:(nullable NSString *)reason wasClean:(BOOL)wasClean;
 
 /**
  Called on receive of a ping message from the server.

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -778,7 +778,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
     [self assertOnWorkQueue];
 
     if (self.readyState == SR_OPEN) {
-        [self closeWithCode:1000 reason:nil];
+        [self closeWithCode:SRStatusCodeNormal reason:nil];
     }
     dispatch_async(_workQueue, ^{
         [self closeConnection];

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -124,7 +124,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
     BOOL _sentClose;
     BOOL _didFail;
     BOOL _cleanupScheduled;
-    int _closeCode;
+    SRStatusCode _closeCode;
 
     BOOL _isPumping;
 
@@ -512,7 +512,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
     [self closeWithCode:SRStatusCodeNormal reason:nil];
 }
 
-- (void)closeWithCode:(NSInteger)code reason:(NSString *)reason
+- (void)closeWithCode:(SRStatusCode)code reason:(NSString *)reason
 {
     assert(code);
     __weak typeof(self) wself = self;


### PR DESCRIPTION
This pull request changes the type of the `closeWithCode:reason:` method's `code` parameter from `NSInteger` to `SRStatusCode`.

### Changes

- Replaced `NSInteger` with `SRStatusCode` for close codes in the `SRWebSocketDelegate` protocol's `webSocket:didCloseWithCode:reason:wasClean:` method.
- Replaced `NSInteger` with `SRStatusCode` for the `closeWithCode:reason:` method in the `SRWebSocket` class.
- Updated the `_closeCode` internal property from `int` to `SRStatusCode` for type safety.
- Replaced the magic number `1000` with `SRStatusCodeNormal` for better readability.
- Updated the `README.md` to reflect the new method signature.

### Motivation

This change improves type safety and clarity by using the specific `SRStatusCode` enum for WebSocket close codes, instead of a generic `NSInteger`. This helps developers avoid passing invalid values and makes the code's intent more explicit. The use of `SRStatusCodeNormal` instead of `1000` also improves code readability.

### Breaking Change

This is a **breaking change** as it alters the public API of `SRWebSocket` and `SRWebSocketDelegate`. Users who have implemented the delegate method or called the `closeWithCode:reason:` method will need to update their code to use `SRStatusCode`.